### PR TITLE
feat(cache)!: refactors query and remove API

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ license = "MIT"
 keywords = ["cache", "lru-cache", "generational-arena", "no-std"]
 categories = ["algorithms", "caching"]
 exclude = [".github/"]
-version = "0.1.2"
+version = "0.2.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/README.md
+++ b/README.md
@@ -63,15 +63,8 @@ assert_eq!(cache.insert(-2, 42).unwrap(), Eviction::Value(2));
 assert_eq!(cache.least_recent().unwrap(), (&-3, &3));
 assert_eq!(cache.most_recent().unwrap(), (&-2, &42));
 
-match cache.remove(&-42) {
-  Ok(Lookup::Miss) => {},
-  _ => unreachable!("Wrong result on cache miss"),
-};
-
-match cache.query(&-42) {
-  Ok(Lookup::Miss) => {},
-  _ => unreachable!("Wrong result on cache miss"),
-};
+assert_eq!(cache.remove(&-42).unwrap(), Lookup::Miss);
+assert_eq!(cache.query(&-42).unwrap(), Lookup::Miss);
 
 assert_eq!(cache.query(&-3).unwrap(), Lookup::Hit(&3));
 
@@ -80,10 +73,7 @@ assert_eq!(cache.most_recent().unwrap(), (&-3, &3));
 
 assert_eq!(cache.remove(&-2).unwrap(), Lookup::Hit(42));
 
-match cache.query(&-2) {
-  Ok(Lookup::Miss) => {},
-  _ => unreachable!("Wrong result on cache miss"),
-};
+assert_eq!(cache.query(&-2).unwrap(), Lookup::Miss);
 
 // zero capacity LRUCache is unusable
 let mut cache = LRUCache::<_, i32, u64, AllocBTreeMap<_, _>>::with_backing_vector(Array::<_, 0_usize>::new());

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Generational Arena based cache impls. in 100% safe, [no_std] compatible Rust.
 
 ```toml
 [dependencies]
-generational-cache = "0.1.2"
+generational-cache = "0.2.0"
 ```
 
 Refer to latest git [API Documentation](https://arindas.github.io/generational-cache/docs/generational_cache/)

--- a/README.md
+++ b/README.md
@@ -64,25 +64,25 @@ assert_eq!(cache.least_recent().unwrap(), (&-3, &3));
 assert_eq!(cache.most_recent().unwrap(), (&-2, &42));
 
 match cache.remove(&-42) {
-  Err(LRUCacheError::CacheMiss) => {},
-  _ => unreachable!("Wrong error on cache miss"),
+  Ok(Lookup::Miss) => {},
+  _ => unreachable!("Wrong result on cache miss"),
 };
 
 match cache.query(&-42) {
-  Err(LRUCacheError::CacheMiss) => {},
-  _ => unreachable!("Wrong error on cache miss"),
+  Ok(Lookup::Miss) => {},
+  _ => unreachable!("Wrong result on cache miss"),
 };
 
-assert_eq!(cache.query(&-3).unwrap(), &3);
+assert_eq!(cache.query(&-3).unwrap(), Lookup::Hit(&3));
 
 assert_eq!(cache.least_recent().unwrap(), (&-4, &4));
 assert_eq!(cache.most_recent().unwrap(), (&-3, &3));
 
-assert_eq!(cache.remove(&-2).unwrap(), 42);
+assert_eq!(cache.remove(&-2).unwrap(), Lookup::Hit(42));
 
 match cache.query(&-2) {
-  Err(LRUCacheError::CacheMiss) => {},
-  _ => unreachable!("Wrong error on cache miss"),
+  Ok(Lookup::Miss) => {},
+  _ => unreachable!("Wrong result on cache miss"),
 };
 
 // zero capacity LRUCache is unusable

--- a/src/cache/lru_cache.rs
+++ b/src/cache/lru_cache.rs
@@ -26,15 +26,8 @@
 //! assert_eq!(cache.least_recent().unwrap(), (&-3, &3));
 //! assert_eq!(cache.most_recent().unwrap(), (&-2, &42));
 //!
-//! match cache.remove(&-42) {
-//!   Ok(Lookup::Miss) => {},
-//!   _ => unreachable!("Wrong result on cache miss"),
-//! };
-//!
-//! match cache.query(&-42) {
-//!   Ok(Lookup::Miss) => {},
-//!   _ => unreachable!("Wrong result on cache miss"),
-//! };
+//! assert_eq!(cache.remove(&-42).unwrap(), Lookup::Miss);
+//! assert_eq!(cache.query(&-42).unwrap(), Lookup::Miss);
 //!
 //! assert_eq!(cache.query(&-3).unwrap(), Lookup::Hit(&3));
 //!
@@ -43,10 +36,7 @@
 //!
 //! assert_eq!(cache.remove(&-2).unwrap(), Lookup::Hit(42));
 //!
-//! match cache.query(&-2) {
-//!   Ok(Lookup::Miss) => {},
-//!   _ => unreachable!("Wrong result on cache miss"),
-//! };
+//! assert_eq!(cache.query(&-2).unwrap(), Lookup::Miss);
 //!
 //! // zero capacity LRUCache is unusable
 //! let mut cache = LRUCache::<_, i32, u64, AllocBTreeMap<_, _>>::with_backing_vector(Array::<_, 0_usize>::new());
@@ -343,15 +333,8 @@ pub mod tests {
         assert_eq!(cache.least_recent().unwrap(), (&2, &2));
         assert_eq!(cache.most_recent().unwrap(), (&1, &1));
 
-        match cache.remove(&(capacity + 1)) {
-            Ok(Lookup::Miss) => {}
-            _ => unreachable!("Wrong result on cache miss"),
-        };
-
-        match cache.query(&(capacity + 1)) {
-            Ok(Lookup::Miss) => {}
-            _ => unreachable!("Wrong result on cache miss"),
-        };
+        assert_eq!(cache.remove(&(capacity + 1)).unwrap(), Lookup::Miss);
+        assert_eq!(cache.query(&(capacity + 1)).unwrap(), Lookup::Miss);
 
         assert_eq!(
             cache.insert(capacity + 1, capacity + 1).unwrap(),
@@ -363,10 +346,8 @@ pub mod tests {
             Lookup::Hit(capacity + 1)
         );
 
-        match cache.query(&(capacity + 1)) {
-            Ok(Lookup::Miss) => {}
-            _ => unreachable!("Wrong result on cache miss"),
-        };
+        assert_eq!(cache.remove(&(capacity + 1)).unwrap(), Lookup::Miss);
+        assert_eq!(cache.query(&(capacity + 1)).unwrap(), Lookup::Miss);
 
         assert_eq!(
             cache.insert(capacity, capacity + 2).unwrap(),

--- a/src/cache/lru_cache.rs
+++ b/src/cache/lru_cache.rs
@@ -27,25 +27,25 @@
 //! assert_eq!(cache.most_recent().unwrap(), (&-2, &42));
 //!
 //! match cache.remove(&-42) {
-//!   Err(LRUCacheError::CacheMiss) => {},
-//!   _ => unreachable!("Wrong error on cache miss"),
+//!   Ok(Lookup::Miss) => {},
+//!   _ => unreachable!("Wrong result on cache miss"),
 //! };
 //!
 //! match cache.query(&-42) {
-//!   Err(LRUCacheError::CacheMiss) => {},
-//!   _ => unreachable!("Wrong error on cache miss"),
+//!   Ok(Lookup::Miss) => {},
+//!   _ => unreachable!("Wrong result on cache miss"),
 //! };
 //!
-//! assert_eq!(cache.query(&-3).unwrap(), &3);
+//! assert_eq!(cache.query(&-3).unwrap(), Lookup::Hit(&3));
 //!
 //! assert_eq!(cache.least_recent().unwrap(), (&-4, &4));
 //! assert_eq!(cache.most_recent().unwrap(), (&-3, &3));
 //!
-//! assert_eq!(cache.remove(&-2).unwrap(), 42);
+//! assert_eq!(cache.remove(&-2).unwrap(), Lookup::Hit(42));
 //!
 //! match cache.query(&-2) {
-//!   Err(LRUCacheError::CacheMiss) => {},
-//!   _ => unreachable!("Wrong error on cache miss"),
+//!   Ok(Lookup::Miss) => {},
+//!   _ => unreachable!("Wrong result on cache miss"),
 //! };
 //!
 //! // zero capacity LRUCache is unusable
@@ -68,6 +68,8 @@ use core::{
     fmt::{Debug, Display},
     mem,
 };
+
+use super::Lookup;
 
 extern crate alloc;
 
@@ -148,7 +150,6 @@ pub enum LRUCacheError<VE, ME> {
     ListUnderflow,
     MapListInconsistent,
     MapError(ME),
-    CacheMiss,
 }
 
 impl<VE, ME> Display for LRUCacheError<VE, ME>
@@ -209,15 +210,15 @@ where
         Ok(eviction)
     }
 
-    fn remove(&mut self, key: &K) -> Result<T, Self::Error> {
-        let link = self.block_refs.remove(key).ok_or(Self::Error::CacheMiss)?;
-
-        let block = self
-            .block_list
-            .remove(&link)
-            .ok_or(Self::Error::MapListInconsistent)?;
-
-        Ok(block.value)
+    fn remove(&mut self, key: &K) -> Result<Lookup<T>, Self::Error> {
+        match self.block_refs.remove(key) {
+            Some(link) => self
+                .block_list
+                .remove(&link)
+                .map(|x| Lookup::Hit(x.value))
+                .ok_or(Self::Error::MapListInconsistent),
+            _ => Ok(Lookup::Miss),
+        }
     }
 
     fn shrink(&mut self, new_capacity: usize) -> Result<(), Self::Error> {
@@ -249,19 +250,20 @@ where
         Ok(())
     }
 
-    fn query(&mut self, key: &K) -> Result<&T, Self::Error> {
-        let link = self.block_refs.get(key).ok_or(Self::Error::CacheMiss)?;
+    fn query(&mut self, key: &K) -> Result<Lookup<&T>, Self::Error> {
+        match self.block_refs.get(key) {
+            Some(link) => {
+                self.block_list
+                    .shift_push_back(link)
+                    .ok_or(Self::Error::MapListInconsistent)?;
 
-        self.block_list
-            .shift_push_back(link)
-            .ok_or(Self::Error::MapListInconsistent)?;
-
-        let block = self
-            .block_list
-            .get(link)
-            .ok_or(Self::Error::MapListInconsistent)?;
-
-        Ok(&block.value)
+                self.block_list
+                    .get(link)
+                    .map(|x| Lookup::Hit(&x.value))
+                    .ok_or(Self::Error::MapListInconsistent)
+            }
+            _ => Ok(Lookup::Miss),
+        }
     }
 
     fn capacity(&self) -> usize {
@@ -288,7 +290,8 @@ where
 pub mod tests {
 
     use super::{
-        Cache, Eviction, LRUCache, LRUCacheBlockArenaEntry, LRUCacheError, Link, Map, Vector,
+        Cache, Eviction, LRUCache, LRUCacheBlockArenaEntry, LRUCacheError, Link, Lookup, Map,
+        Vector,
     };
 
     pub fn _test_cache_correctness<VX, VY, M>(zero_capacity_vec: VX, test_vec: VY)
@@ -335,19 +338,19 @@ pub mod tests {
             Eviction::Block { key: 0, value: 0 }
         );
 
-        assert_eq!(cache.query(&1).unwrap(), &1);
+        assert_eq!(cache.query(&1).unwrap(), Lookup::Hit(&1));
 
         assert_eq!(cache.least_recent().unwrap(), (&2, &2));
         assert_eq!(cache.most_recent().unwrap(), (&1, &1));
 
         match cache.remove(&(capacity + 1)) {
-            Err(LRUCacheError::CacheMiss) => {}
-            _ => unreachable!("Wrong error on cache miss"),
+            Ok(Lookup::Miss) => {}
+            _ => unreachable!("Wrong result on cache miss"),
         };
 
         match cache.query(&(capacity + 1)) {
-            Err(LRUCacheError::CacheMiss) => {}
-            _ => unreachable!("Wrong error on cache miss"),
+            Ok(Lookup::Miss) => {}
+            _ => unreachable!("Wrong result on cache miss"),
         };
 
         assert_eq!(
@@ -355,11 +358,14 @@ pub mod tests {
             Eviction::Block { key: 2, value: 2 }
         );
 
-        assert_eq!(cache.remove(&(capacity + 1)).unwrap(), capacity + 1);
+        assert_eq!(
+            cache.remove(&(capacity + 1)).unwrap(),
+            Lookup::Hit(capacity + 1)
+        );
 
         match cache.query(&(capacity + 1)) {
-            Err(LRUCacheError::CacheMiss) => {}
-            _ => unreachable!("Wrong error on cache miss"),
+            Ok(Lookup::Miss) => {}
+            _ => unreachable!("Wrong result on cache miss"),
         };
 
         assert_eq!(

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -8,19 +8,25 @@ pub enum Eviction<K, V> {
     None,
 }
 
+#[derive(Debug, PartialEq, Eq)]
+pub enum Lookup<V> {
+    Hit(V),
+    Miss,
+}
+
 /// A size bounded map, where certain existing entries are evicted to make space for new entires.
 pub trait Cache<K, V> {
     type Error;
 
     fn insert(&mut self, key: K, value: V) -> Result<Eviction<K, V>, Self::Error>;
 
-    fn remove(&mut self, key: &K) -> Result<V, Self::Error>;
+    fn remove(&mut self, key: &K) -> Result<Lookup<V>, Self::Error>;
 
     fn shrink(&mut self, new_capacity: usize) -> Result<(), Self::Error>;
 
     fn reserve(&mut self, additional: usize) -> Result<(), Self::Error>;
 
-    fn query(&mut self, key: &K) -> Result<&V, Self::Error>;
+    fn query(&mut self, key: &K) -> Result<Lookup<&V>, Self::Error>;
 
     fn capacity(&self) -> usize;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,7 @@ pub mod prelude {
         arena::{Arena, ArenaError},
         cache::{
             lru_cache::{LRUCache, LRUCacheError},
-            Cache, Eviction,
+            Cache, Eviction, Lookup,
         },
         collections::list::{Link, LinkedList, ListError},
         map::{impls::alloc_btree_map::AllocBTreeMap, Map},

--- a/src/vector/mod.rs
+++ b/src/vector/mod.rs
@@ -35,7 +35,7 @@ pub mod tests {
         assert!(vector.is_empty());
 
         for i in 0..vector.capacity() {
-            assert!(matches!(vector.push(i), Ok(_)));
+            vector.push(i).unwrap();
         }
 
         assert_eq!(vector.len(), vector.capacity());
@@ -76,7 +76,7 @@ pub mod tests {
         }
 
         for i in 0..ADDITIONAL {
-            assert!(matches!(vector.push(i), Ok(_)));
+            vector.push(i).unwrap();
         }
     }
 }


### PR DESCRIPTION
- query() and remove() return Lookup objects instead of plain values or references
- Lookup::Hit(value) on hit
- Lookup::Miss on miss